### PR TITLE
Describe the use of job arrays.

### DIFF
--- a/software-packages/flacs.rst
+++ b/software-packages/flacs.rst
@@ -93,7 +93,7 @@ account in SAFE (SAFE Guide: :doc:`../safe-guide/safe-guide-users`).
 The ``-l select=x:ncpus=y`` option specifies the resource allocation for
 the job you are starting. The parameter ``x`` is the number of nodes
 required and the parameter ``y`` is the number of cores required. For
-a serial FLACS job you woudl use ``-l select=1:ncpus=1``
+a serial FLACS job you would use ``-l select=1:ncpus=1``
 
 All Flacs jobs must be submitted to the flacs queue using the option
 ``-q flacs``; the flacs queue ensures FLACS licenses are provisioned
@@ -134,9 +134,9 @@ could look like this:
 ::
 
    module load flacs/10.5.1
-   sleep 5; qsub -A xyz -l select=2 -N f-000012 -q flacs -V -- `which run_runflacs` -dir `pwd` 000012
-   sleep 5; qsub -A xyz -l select=2 -N f-000023 -q flacs -V -- `which run_runflacs` -dir `pwd` 000023
-   sleep 5; qsub -A xyz -l select=2 -N f-000117 -q flacs -V -- `which run_runflacs` -dir `pwd` 000117
+   sleep 5; qsub -A xyz -l select=1:ncpus=1 -N f-000012 -q flacs -V -- `which run_runflacs` -dir `pwd` 000012
+   sleep 5; qsub -A xyz -l select=1:ncpus=1 -N f-000023 -q flacs -V -- `which run_runflacs` -dir `pwd` 000023
+   sleep 5; qsub -A xyz -l select=1:ncpus=1 -N f-000117 -q flacs -V -- `which run_runflacs` -dir `pwd` 000117
 
 This is also easy to formulate as a loop. 
 

--- a/software-packages/flacs.rst
+++ b/software-packages/flacs.rst
@@ -153,6 +153,49 @@ only your jobs use:
    qstat -u username
 
 
+Submitting many FLACS jobs as a job array
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Running many related scenarios with the Flacs simulator is ideally suited for
+using `job arrays <../user-guide/batch.html#job-arrays>`_, i.e. running the
+simulations as part of a single job.
+
+A job script for running a job array with 128 Flacs scenarios that are located in
+the current directory could look like this:
+
+::
+
+    #!/bin/bash --login
+    #PBS -l select=1:ncpus=1
+    #PBS -N disp2
+    #PBS -J 1-128
+    #PBS -j oe
+    #PBS -l walltime=48:00:00
+    #PBS -q flacs
+    #PBS -V
+
+    cd ${PBS_O_WORKDIR}
+
+    CS_FILES=(`ls -1 cs??????.dat3`)
+    # NR_OF_JOBS=${#CS_FILES[@]}
+    JOB_FIRST=1
+    JOB_LAST=128
+    for (( i=0; i<$(expr ${JOB_LAST} - ${JOB_FIRST}); i++ ));
+    do
+      JOB_IDS[${i}]=${CS_FILES[$(expr $i + ${JOB_FIRST})]:2:6}
+    done
+
+    module load flacs
+    JOB_INDEX=$(( $PBS_ARRAY_INDEX - 1 ))
+
+    `which run_runflacs` ${JOB_IDS[${JOB_INDEX}]}
+
+Due to the way the job scheduler interprets this script, the number
+of jobs has to be hard-coded in the first (non-bash) part of the job
+script and cannot be determined based on the number of scenarios in
+the current directory.
+
+
 Transfer data from Cirrus to your local system
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/user-guide/batch.rst
+++ b/user-guide/batch.rst
@@ -367,7 +367,7 @@ have set MPI_SHEPHERD=true
 MPI on the login nodes
 ~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to run a short interactive parallel applications (e.g. for 
+If you want to run short interactive parallel applications (e.g. for 
 debugging) then you can run compiled MPI applications on the login nodes.
 
 For instance, to run a simple, short 4-way MPI job on the login node, issue the
@@ -378,7 +378,7 @@ following command (once you have loaded the appropriate modules):
     mpirun -n 4 ./hello_mpi.x
 
 **Note:** you should not run long, compute- or memory-intensive jobs on the 
-login nodes. Any such processes a liable to termination by the system
+login nodes. Any such processes are liable to termination by the system
 with no warning.
 
 Serial Jobs
@@ -416,6 +416,91 @@ A simple serial script to compress a file would be:
 
     # Run the serial executable
     gzip my_big_file.dat
+
+.. _jobarrays:
+
+Job arrays
+----------
+
+The PBSPro job scheduling system offers the *job array* concept,
+for running collections of almost-identical jobs, for example
+running the same program several times with different arguments
+or input data.
+
+Each job in a job array is called a *subjob*.  The subjobs of a job
+array can be submitted and queried as a unit, making it easier and
+cleaner to handle the full set, compared to individual jobs.
+
+All subjobs in a job array are started by running the same job script.
+The job script also contains information on the number of jobs to be
+started, and PBSPro provides a subjob index which can be passed to
+the individual subjobs or used to select the input data per subjob.
+
+
+Job script for a job array
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As an example, to start 56 subjobs, with the subjob index as the only
+argument, and 4 hours maximum runtime per subjob, save the following
+content into the file job_script.pbs:
+
+::
+
+    #!/bin/bash --login
+    #PBS -l select=1:ncpus=1
+    #PBS -l walltime=04:00:00
+    #PBS -J 1-56
+    #PBS -q workq
+    #PBS -V
+
+    cd ${PBS_O_WORKDIR}
+
+    /path/to/exe $PBS_ARRAY_INDEX
+
+Another example of a job script for submitting a job array is given
+`here <../software-packages/flacs.html#submitting-many-flacs-jobs-as-a-job-array>`_.
+
+
+Starting a job array
+~~~~~~~~~~~~~~~~~~~~
+
+When starting a job array, most options can be included in the job
+file, but the project code for the resource billing has to be
+specified on the command line:
+
+::
+
+    qsub -A [project code] job_script.pbs
+
+
+Querying a job array
+~~~~~~~~~~~~~~~~~~~~
+
+In the normal PBSPro job status, a job array will be shown as a single
+line:
+
+::
+
+    > qstat       
+    Job id            Name           User   Time Use S Queue
+    ----------------  -------------- ------ -------- - -----
+    112452[].indy2-lo dispsim        user1         0 B workq
+
+To monitor the subjobs of the job 112452, use
+
+::
+
+    > qstat -t 1235[]
+    Job id            Name             User              Time Use S Queue
+    ----------------  ---------------- ----------------  -------- - -----
+    112452[].indy2-lo dispsim          user1                    0 B flacs           
+    112452[1].indy2-l dispsim          user1             02:45:37 R flacs           
+    112452[2].indy2-l dispsim          user1             02:45:56 R flacs           
+    112452[3].indy2-l dispsim          user1             02:45:33 R flacs           
+    112452[4].indy2-l dispsim          user1             02:45:45 R flacs           
+    112452[5].indy2-l dispsim          user1             02:45:26 R flacs           
+    ...
+
 
 Interactive Jobs
 ----------------


### PR DESCRIPTION
Slightly improved over yesterday's version. Links should now be correct.