### PR TITLE
Clarify reservation request commands

### DIFF
--- a/user-guide/batch.rst
+++ b/user-guide/batch.rst
@@ -775,7 +775,12 @@ full nodes (144 physical cores, 288 hyperthreads) and charge to project "t01" yo
 
 ::
 
-   [auser@cirrus-login0 ~]$ pbs_rsub -R 1708261030 -D 3:0:0 -l select=6:ncpus=36,place=scatter:excl -G +t01
+   pbs_rsub -R 1708261030 -D 3:0:0 -l select=6:ncpus=36,place=scatter:excl -G +t01
+   
+Generating response:
+
+::
+
    R122604.indy2-login0 UNCONFIRMED
 
 The command will return a reservation ID (``R122604`` in the example above) and note that 
@@ -799,7 +804,12 @@ You can cheack the status of your reservation request with the ``pbs_rstat`` com
 
 ::
 
-   [auser@cirrus-login0 ~]$ pbs_rstat
+   pbs_rstat
+   
+Which will generate a response:
+
+::
+
    Resv ID    Queue    User     State             Start / Duration / End              
    ---------------------------------------------------------------------
    R122604.in R122605  auser@ CO            Sat 10:30 / 10800 / Sat 13:30 
@@ -836,7 +846,12 @@ September 2017 for 64 nodes accessible by all users in the t01 project you would
 
 ::
 
-   [auser@cirrus-login0 ~]$ pbs_rsub -R 1709181615 -D 192:0:0 -l select=66:ncpus=36,place=scatter:excl -G +t01 -U +
+   pbs_rsub -R 1709181615 -D 192:0:0 -l select=66:ncpus=36,place=scatter:excl -G +t01 -U +
+   
+Generating a response:
+
+::
+
    R122605.indy2-login0 UNCONFIRMED
 
 Here, the ``-G +t01`` option charges the reservation to the t01 project **and** restricts access to


### PR DESCRIPTION
Split the lines in the docs relating to the command to request a reservation, and the response sent by pbs, as the current version, where both the command and response are shown in one box, led to at least one user being confused (and including the response part in their request command, leading to errors they did not understand).
