### PR TITLE
Updating references to Sylabs.io

### DIFF
--- a/user-guide/singularity.rst
+++ b/user-guide/singularity.rst
@@ -6,7 +6,7 @@ This page was originally based on the documentation at the `University of Sheffi
 
 Designed around the notion of mobility of compute and reproducible science,
 Singularity enables users to have full control of their operating system environment.
-This means that a non-privileged user can "swap out" the Linux operating system and 
+This means that a non-privileged user can "swap out" the Linux operating system and
 environment on the host for a Linux OS and environment that they control.
 So if the host system is running CentOS Linux but your application runs in Ubuntu Linux
 with a particular software stack; you can create an Ubuntu image, install your software
@@ -25,8 +25,8 @@ rather than Singularity).
 Useful Links
 ------------
 
-* `Singularity website <http://singularity.lbl.gov/>`_
-* `Singularity user documentation <http://singularity.lbl.gov/user-guide>`_
+* `Singularity website <https://www.sylabs.io/>`_
+* `Singularity documentation <https://www.sylabs.io/docs/>`_
 
 About Singularity Containers (Images)
 -------------------------------------
@@ -64,7 +64,7 @@ Singularity images can be used on Cirrus in a number of ways, including:
 * As serial processes within a non-interactive batch script
 * As parallel processes within a non-interactive batch script (not yet documented)
 
-We provide information on each of these scenarios (apart from the parallel use where 
+We provide information on each of these scenarios (apart from the parallel use where
 we are still preparing the documentation) below. First, we describe briefly how to
 get exisitng images onto Cirrus so you can use them.
 
@@ -81,17 +81,17 @@ This functionality requires tools that are not part of the standard OS on Cirrus
 provided a Singularity image that allows you to build images from remote repositories (i.e.
 you use a Singularity image to build Singularity images!).
 
-For example, to retrieve an image from DockerHub on Cirrus we fist need to enter an 
+For example, to retrieve an image from DockerHub on Cirrus we fist need to enter an
 interactive session in the image we provide for building Singularity images:
 
 ::
 
    [user@cirrus-login0 ~]$ module load singularity
    [user@cirrus-login0 ~]$ singularity exec $CIRRUS_SIMG/cirrus-sbuild.simg /bin/bash --login
-   Singularity> 
+   Singularity>
 
-This invokes a login bash shell within the ``$CIRRUS_SIMG/cirrus-sbuild.simg`` image as 
-indicated by our prompt change. (We need a login shell to allow ``module`` commands to work 
+This invokes a login bash shell within the ``$CIRRUS_SIMG/cirrus-sbuild.simg`` image as
+indicated by our prompt change. (We need a login shell to allow ``module`` commands to work
 within the image.)
 
 Now we are in the image we can load the singularity module (to get access to the Singularity
@@ -131,7 +131,7 @@ different ways to use images below.
 
 Similar syntax can be used for Singularity Hub. For more information see the Singularity documentation:
 
-* `Build a Container <http://singularity.lbl.gov/docs-build-container>`_
+* `Build a Container <https://www.sylabs.io/guides/2.6/user-guide/build_a_container.html>`_
 
 
 Interactive use on the login nodes
@@ -145,8 +145,8 @@ you use the ``singularity shell`` command. Using the image we built in the examp
    [user@cirrus-login0 ~]$ module load singularity
    [user@cirrus-login0 ~]$ singularity shell lolcow.simg
    Singularity: Invoking an interactive shell within container...
-   
-   Singularity lolcow.simg:~> 
+
+   Singularity lolcow.simg:~>
 
 Within a Singularity image your home directory will be available. The directory with
 centrally-installed software (``/lustre/sw``) is also available in images by default. Note that
@@ -165,7 +165,7 @@ Once you have finished using your image, you return to the Cirrus login node com
 Interactive use on the compute nodes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The process for using an image interactively on the compute nodes is very similar to that for 
+The process for using an image interactively on the compute nodes is very similar to that for
 using them on the login nodes. The only difference is that you have to submit an interactive
 serial job to get interactive access to the compute node first.
 
@@ -175,11 +175,11 @@ For example, to reserve a full node for you to work on interactively you would u
 
    [user@cirrus-login0 ~]$ qsub -IVl select=1:ncpus=36,walltime=0:20:0,place=scatter:excl -A t01
    qsub: waiting for job 234192.indy2-login0 to start
-   
+
    ...wait until job starts...
-   
+
    qsub: job 234192.indy2-login0 ready
-   
+
    [user@r1i2n13 ~]$
 
 Note the prompt has changed to show you are on a compute node. Now you can use the image
@@ -190,7 +190,7 @@ in the same way as on the login node
    [user@r1i2n13 ~]$ module load singularity
    [user@r1i2n13 ~]$ singularity shell lolcow.simg
    Singularity: Invoking an interactive shell within container...
-      
+
    Singularity lolcow.simg:~> exit
    exit
    [user@r1i2n13 ~]$ exit
@@ -240,14 +240,14 @@ usual way.
 Creating Your Own Singularity Images
 ------------------------------------
 
-As we saw above, you can create Singularity images by importing from 
+As we saw above, you can create Singularity images by importing from
 DockerHub or Singularity Hub on Cirrus itself. If you wish to create your
 own custom image then you must install Singularity on a system where you
-have root (or administrator) privileges - often your own laptop or 
+have root (or administrator) privileges - often your own laptop or
 workstation.
 
-We provide links below to instructions on how to install Singularity 
-locally and then cover what options you need to include in a 
+We provide links below to instructions on how to install Singularity
+locally and then cover what options you need to include in a
 Singularity recipe file to create images that can run on Cirrus and
 access the software development modules. (This can be useful if you
 want to create a custom environment but still want to compile and
@@ -266,12 +266,12 @@ If yout are using Windows or macOS, the simplest solution is to use
 environment with Linux and Singularity installed. The Singularity website
 has instructions on how to use this method to install Singularity:
 
-* `Installing Singularity on macOS with Vagrant <http://singularity.lbl.gov/install-mac>`_
-* `Installing Singularity on Windows with Vagrant <http://singularity.lbl.gov/install-windows>`_
+* `Installing Singularity on macOS with Vagrant <https://www.sylabs.io/guides/2.6/user-guide/installation.html#install-on-mac>`_
+* `Installing Singularity on Windows with Vagrant <https://www.sylabs.io/guides/2.6/user-guide/installation.html#install-on-windows>`_
 
 If you are using Linux then you can usually install Singularity directly, see:
 
-* `Installing Singularity on Linux <http://singularity.lbl.gov/install-linux>`_
+* `Installing Singularity on Linux <https://www.sylabs.io/guides/2.6/user-guide/installation.html#install-on-linux>`_
 
 Singularity Recipes to Access modules on Cirrus
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -284,10 +284,10 @@ are easily translated for other flavours of Linux.
 For the Cirrus modules to be available in your Singularity container you need to
 ensure that the ``environment-modules`` package is installed in your image.
 
-In addition, when you use the container you must invoke access as a login 
+In addition, when you use the container you must invoke access as a login
 shell to have access to the module commands.
 
-Here is an example recipe file to build a CentOS 7 image with access to 
+Here is an example recipe file to build a CentOS 7 image with access to
 TCL modules alread installed on Cirrus:
 
 ::
@@ -307,7 +307,7 @@ system where you have root access, not Cirrus):
 
    me@my-system:~> sudo singularity build cirrus-mods.simg cirrus-mods.def
 
-The resulting image file (``cirrus-mods.simg``) can then be compied to Cirrus 
+The resulting image file (``cirrus-mods.simg``) can then be compied to Cirrus
 using scp.
 
 When you use the image interactively on Cirrus you must start with a login
@@ -318,9 +318,8 @@ shell, i.e.:
    [user@cirrus-login0 ~]$ module load singularity
    [user@cirrus-login0 ~]$ singularity exec cirrus-mods.simg /bin/bash --login
    Singularity> module avail intel-compilers
-   
+
    ------------------------- /lustre/sw/modulefiles ---------------------
    intel-compilers-16/16.0.2.181
    intel-compilers-16/16.0.3.210(default)
    intel-compilers-17/17.0.2.174(default)
-


### PR DESCRIPTION
As it should be of your knowledge, we are moving and also updating and keeping the latest documentation about Singularity on our Sylabs site, so now you will find the latest about Singularity documentation here: https://www.sylabs.io/docs/ 

We recommend updating other references you may have since http://singularity.lbl.gov/ will not be maintained anymore. Thank you.