### PR TITLE
Update forge module

### DIFF
--- a/software-tools/ddt.rst
+++ b/software-tools/ddt.rst
@@ -12,7 +12,7 @@ you will need to load the Allinea Forge module and execute ``forge``:
 
 ::
 
-    module load allinea
+    module load forge
     forge
 
 Debugging runs on the login nodes


### PR DESCRIPTION
Currently the allinea module is listed in the docs, but we should be using the forge module now.