### PR TITLE
Added warning noting need for core hours if one is going to run GPU jobs

### DIFF
--- a/user-guide/batch.rst
+++ b/user-guide/batch.rst
@@ -162,6 +162,11 @@ you will be assigned a maximum of 384/4 = 96 GB of the memory available on the n
    Using the ``--exclusive`` option in jobs will give you access to all of the CPU cores and the full node memory even
    if you do not explicitly request all of the GPU cards on the node.
 
+.. warning::
+
+   In order to run jobs on the GPU nodes your budget must have positive GPU hours *and* core hours associated with it.
+   However, only your GPU hours will be consumed when running these jobs.
+
 Partitions
 ~~~~~~~~~~
 

--- a/user-guide/gpu.rst
+++ b/user-guide/gpu.rst
@@ -153,6 +153,11 @@ you will be assigned a maximum of 384/4 = 96 GB of the memory available on the n
    Using the ``--exclusive`` option in jobs will give you access to all of the CPU cores and the full node memory even
    if you do not explicitly request all of the GPU cards on the node.
 
+.. warning::
+
+   In order to run jobs on the GPU nodes your budget must have positive GPU hours *and* core hours associated with it.
+   However, only your GPU hours will be consumed when running these jobs.
+
 Partitions
 ~~~~~~~~~~
 


### PR DESCRIPTION
I added warnings to the 'Running jobs on Cirrus' and 'Using the Cirrus GPU nodes' sections noting that users will also need to have positive core hours on their budgets if they want to run GPU jobs.