### PR TITLE
Update and fix GPU QoS

### DIFF
--- a/user-guide/batch.rst
+++ b/user-guide/batch.rst
@@ -246,7 +246,7 @@ following table has a list of active QoS on Cirrus.
      - 
    * - gpu
      - No limit
-     - 50 jobs
+     - 128 jobs
      - 4 days
      - 64 GPUs (16 nodes~40%)
      - gpu-skylake, gpu-cascade

--- a/user-guide/gpu.rst
+++ b/user-guide/gpu.rst
@@ -250,21 +250,30 @@ Quality of Service (QoS)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Quality of Service (QoS) is used alongside the partition to control how work
-is allocated to the available resources. There is only one relevant QoS
+is allocated to the available resources. There are two relevant QoSes
 for GPU jobs:
 
-.. list-table::
-   :widths: 20 20 20 40
+.. list-table:: GPU QoS
    :header-rows: 1
 
-   * - QoS
-     - Description
-     - Maximum Walltime
-     - Other Limits
+   * - QoS Name
+     - Jobs Running Per User
+     - Jobs Queued Per User
+     - Max Walltime
+     - Max Size
+     - GPU Partition
    * - gpu
-     - GPU QoS
-     - 96 hours
-     - max. 16 GPUs per user, max. 10 jobs running per user, max. 50 jobs queued per user
+     - No limit
+     - 128 jobs
+     - 4 days
+     - 64 GPUs
+     - gpu-skylake, gpu-cascade
+   * - short
+     - 1 job
+     - 2 jobs
+     - 20 minutes
+     - 4 GPUs or 2 nodes
+     - gpu-skylake
 
 
 Examples


### PR DESCRIPTION
The max number of submitted jobs to the `gpu` QoS was out-of-date when compared to output from `sacctmgr show qos format="Name,MaxWall,MaxTRESPerUser%30,MaxJob,MaxSubmit"`.

I've also made the QoS table in the GPU documentation resemble the one in the Running Jobs documentation, and noted that the `short` queue can also be used to run small GPU jobs.