### PR TITLE
updating module load documentation as per request of systems

### DIFF
--- a/user-guide/development.rst
+++ b/user-guide/development.rst
@@ -100,8 +100,12 @@ you need a specfic version of the module, you can add more information:
 
     module load intel-compilers-18/18.0.5.274
 
-will load version 18.0.2.274 for you, regardless of the default. If you
-want to clean up, ``module remove`` will remove a loaded module:
+will load version 18.0.2.274 for you, regardless of the default.
+
+If a module loading file cannot be accessed within 10 seconds, a warning message will appear:
+``Warning: Module system not loaded``.
+
+If you want to clean up, ``module remove`` will remove a loaded module:
 
 ::
 


### PR DESCRIPTION
adding line in user documentation to say that an error message will show if a module cannot be loaded

see: https://safe.epcc.ed.ac.uk/TransitionServlet/Query/1846290