### PR TITLE
Update connecting.rst

### DIFF
--- a/user-guide/connecting.rst
+++ b/user-guide/connecting.rst
@@ -6,6 +6,11 @@ directly from a command line terminal or using an SSH client. In
 addition data can be transferred to and from the Cirrus system using
 ``scp`` from the command line or by using a file transfer client.
 
+Before following the process below, we assume you have set up an account on Cirrus through 
+the EPCC SAFE. Documentation on how to do this can be found at:
+ 
+   `SAFE Guide for Users <https://epcced.github.io/safe-docs/safe-for-users/>`__
+
 This section covers the basic connection methods.
 
 Access credentials


### PR DESCRIPTION
We don't actually tell new users how to set up a machine account on Cirrus in the Cirrus docs.
Have copied across the wording linking to the SAFE docs that explain this, as used in the ARCHER2 Docs.
This appears just before telling them how to connect using the account.
Issue raised by user in https://safe.epcc.ed.ac.uk/TransitionServlet/Query/1941245