### PR TITLE
Conda instructions to extend cirrus system conda environments

### DIFF
--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -377,11 +377,13 @@ by running module avail python to see the available choices. Once you have selec
 you should load it. For istance, type
 
 .. code-block:: bash
+    
     module load python/3.9.13
 
 You also need to setup your conda environments. As the compute nodes do not have access to the ``/home`` filesystem, you also need to specify a directory where to save conda configurations and packages on the ``/work`` filesystem. Let us assume you want to install packages in the ``${CONDARC}`` directory.
 To setup the proper environment you need to run the following lines in a shell
 .. code-block:: bash
+    
     export CONDARC=${CONDA_DIR}/.condarc
     eval "$(conda shell.bash hook)"
 
@@ -390,17 +392,22 @@ These two lines need to be called each time you want to use a virtual conda envi
 You also need to tell conda in which directories to save the environments and custom packages.
 
 .. code-block:: bash
+    
     conda config --prepend envs_dirs ${CONDA_DIR}/envs
     conda config --prepend pkgs_dirs ${CONDA_DIR}/pkgs
 
 The above commands need to be executed only once. You can now create a new conda virtual environment based on the default virtual environment using 
 .. code-block:: bash
+    
     conda create --clone base --name ${my_env_name} 
 
 This will create a duplicate environment of the base environment with all the system packages.
 Before starting to install new packages, you need to activate the environment with 
 .. code-block:: bash
+    
     conda activate ${my_env_name}
+
+
 You can now regularly install packages with ``conda install pkg_name``. The packages currently installed in
 in the active environment can be seen with the command ``conda list``.
 

--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -376,33 +376,33 @@ You can decide which module to base your environment on
 by running module avail python to see the available choices. Once you have selected a suitable python module,
 you should load it. For istance, type
 .. code-block:: bash
-  module load python/3.9.13
+    module load python/3.9.13
 
 You also need to setup your conda environments. As the compute nodes do not have access to the ``/home`` filesystem, you also need to specify a directory where to save conda configurations and packages on the ``/work`` filesystem. Let us assume you want to install packages in the ``${CONDARC}`` directory.
 To setup the proper environment you need to run the following lines in a shell
 .. code-block:: bash
-  export CONDARC=${CONDA_DIR}/.condarc
-  eval "$(conda shell.bash hook)"
+    export CONDARC=${CONDA_DIR}/.condarc
+    eval "$(conda shell.bash hook)"
 
 The first line will tell conda to save configuration information in the ``.condarc`` file in ``${CONDA_DIR}``. The second line calls the conda setup script. 
 These two lines need to be called each time you want to use a virtual conda environment.
 You also need to tell conda in which directories to save the environments and custom packages.
 
 .. code-block:: bash
-  conda config --prepend envs_dirs ${CONDA_DIR}/envs
-  conda config --prepend pkgs_dirs ${CONDA_DIR}/pkgs
+    conda config --prepend envs_dirs ${CONDA_DIR}/envs
+    conda config --prepend pkgs_dirs ${CONDA_DIR}/pkgs
 
 The above commands need to be executed only once. You can now create a new conda virtual environment based on the default virtual environment using 
 .. code-block:: bash
-  conda create --clone base --name ${my_env_name} 
+    conda create --clone base --name ${my_env_name} 
 
 This will create a duplicate environment of the base environment with all the system packages.
 Before starting to install new packages, you need to activate the environment with 
 .. code-block:: bash
-  conda activate ${my_env_name}
-
+    conda activate ${my_env_name}
 You can now regularly install packages with ``conda install pkg_name``. The packages currently installed in
 in the active environment can be seen with the command ``conda list``.
+
 
 Using JupyterLab on Cirrus
 --------------------------

--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -368,6 +368,41 @@ You could just as easily create a local virtual environment based on one of the 
 modules is based on a ``python`` module. For example, ``tensorflow/2.11.0-gpu`` is itself an extension of ``python/3.10.8-gpu``
 (and so the ``MINICONDA3_PYTHON_VERSION`` environment variable will be set to ``3.10.8``).
 
+Installing your own Python packages (with conda)
+----------------------------------------------
+To setup a custom Python environment you can use conda  or extend a 
+centrally-installed Miniconda environment.  
+You can decide which module to base your environment on
+by running module avail python to see the available choices. Once you have selected a suitable python module,
+you should load it. For istance, type
+.. code-block:: bash
+  module load python/3.9.13
+
+You also need to setup your conda environments. As the compute nodes do not have access to the ``/home`` filesystem, you also need to specify a directory where to save conda configurations and packages on the ``/work`` filesystem. Let us assume you want to install packages in the ``${CONDARC}`` directory.
+To setup the proper environment you need to run the following lines in a shell
+.. code-block:: bash
+  export CONDARC=${CONDA_DIR}/.condarc
+  eval "$(conda shell.bash hook)"
+
+The first line will tell conda to save configuration information in the ``.condarc`` file in ``${CONDA_DIR}``. The second line calls the conda setup script. 
+These two lines need to be called each time you want to use a virtual conda environment.
+You also need to tell conda in which directories to save the environments and custom packages.
+
+.. code-block:: bash
+  conda config --prepend envs_dirs ${CONDA_DIR}/envs
+  conda config --prepend pkgs_dirs ${CONDA_DIR}/pkgs
+
+The above commands need to be executed only once. You can now create a new conda virtual environment based on the default virtual environment using 
+.. code-block:: bash
+  conda create --clone base --name ${my_env_name} 
+
+This will create a duplicate environment of the base environment with all the system packages.
+Before starting to install new packages, you need to activate the environment with 
+.. code-block:: bash
+  conda activate ${my_env_name}
+
+You can now regularly install packages with ``conda install pkg_name``. The packages currently installed in
+in the active environment can be seen with the command ``conda list``.
 
 Using JupyterLab on Cirrus
 --------------------------

--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -382,6 +382,7 @@ you should load it. For istance, type
 
 You also need to setup your conda environments. As the compute nodes do not have access to the ``/home`` filesystem, you also need to specify a directory where to save conda configurations and packages on the ``/work`` filesystem. Let us assume you want to install packages in the ``${CONDARC}`` directory.
 To setup the proper environment you need to run the following lines in a shell
+
 .. code-block:: bash
     
     export CONDARC=${CONDA_DIR}/.condarc
@@ -397,12 +398,14 @@ You also need to tell conda in which directories to save the environments and cu
     conda config --prepend pkgs_dirs ${CONDA_DIR}/pkgs
 
 The above commands need to be executed only once. You can now create a new conda virtual environment based on the default virtual environment using 
+
 .. code-block:: bash
     
     conda create --clone base --name ${my_env_name} 
 
 This will create a duplicate environment of the base environment with all the system packages.
 Before starting to install new packages, you need to activate the environment with 
+
 .. code-block:: bash
     
     conda activate ${my_env_name}

--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -368,20 +368,20 @@ You could just as easily create a local virtual environment based on one of the 
 modules is based on a ``python`` module. For example, ``tensorflow/2.11.0-gpu`` is itself an extension of ``python/3.10.8-gpu``
 (and so the ``MINICONDA3_PYTHON_VERSION`` environment variable will be set to ``3.10.8``).
 
-Installing your own Python packages (with conda)
+Installing your own Python packages ( with conda )
 ----------------------------------------------
 To setup a custom Python environment you can use conda  or extend a 
 centrally-installed Miniconda environment.  
 You can decide which module to base your environment on
 by running module avail python to see the available choices. Once you have selected a suitable python module,
-you should load it. For istance, type
+you should load it. For instance, type
 
 .. code-block:: bash
     
     module load python/3.9.13
 
 You also need to setup your conda environments. As the compute nodes do not have access to the ``/home`` filesystem, you also need to specify a directory where to save conda configurations and packages on the ``/work`` filesystem. Let us assume you want to install packages in the ``${CONDARC}`` directory.
-To setup the proper environment you need to run the following lines in a shell
+To setup the proper environment you need to run the following lines in a shell 
 
 .. code-block:: bash
     
@@ -413,7 +413,6 @@ Before starting to install new packages, you need to activate the environment wi
 
 You can now regularly install packages with ``conda install pkg_name``. The packages currently installed in
 in the active environment can be seen with the command ``conda list``.
-
 
 Using JupyterLab on Cirrus
 --------------------------

--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -375,6 +375,7 @@ centrally-installed Miniconda environment.
 You can decide which module to base your environment on
 by running module avail python to see the available choices. Once you have selected a suitable python module,
 you should load it. For istance, type
+
 .. code-block:: bash
     module load python/3.9.13
 


### PR DESCRIPTION
I have added instructions on how to install custom packages with conda on top of system libraries. I have checked that one can access system libraries in the new conda environment and that the installation of an extra package ( pyarrow ) is successful. 