### PR TITLE
Update python.md

### DIFF
--- a/docs/user-guide/python.md
+++ b/docs/user-guide/python.md
@@ -546,6 +546,24 @@ you can start from a login node prompt.
     - Please note, you will get a connection error if you haven't used
       the correct node name in step 4 or 5.
 
+!!! Note
+
+	If you have extended a central Python venv following the
+	instructions about for [Installing your own Python packages
+	(with pip)](#installing-your-own-python-packages-(with-pip)),
+	Jupyter Lab will load the central ipython kernel, not the one
+	for your venv. To enable loading of the ipython kernel for your
+	venv from within Jupyter Lab, first install the ipykernel module
+	and then use this to install the kernel for your venv.
+	```
+	source /work/x01/x01/auser/myvenv/bin/activate
+	python -m pip install ipykernel
+	python -m ipykernel install --user --name=myvenv
+	```
+	changing placeholder account and username as appropriate.
+	Thereafter, launch Jupyter Lab as above and select the `myvenv`
+	kernel.
+
 If you are on a compute node, the JupyterLab server will be available
 for the length of the interactive session you have requested.
 


### PR DESCRIPTION
Added note on using Jupyter Lab along with the instructions on extending a central python installation.

If I extend a central python installation following "Installing your own Python packages (with pip)", and install a couple of packages, then launch a Jupyter Lab session, those packages are not available for import. This is because Jupyter Lab loads the IPython kernel associated with the central installation, *not* the extended venv.

One solution would be a `--user` installations of Jupyter and IPython, however this could get bulky and lead to conflicts.

Alternatively, a lighter solution is to install `ipykernel` and add the extended venv as a kernel through that, which then gives a selectable kernel in Jupyter Lab. I've detailed this in the note:
```
source /work/x01/x01/auser/myvenv/bin/activate
python -m pip install ipykernel
python -m ipykernel install --user --name=myvenv
```

This issue may also be present if a user extends central python with conda, but I haven't tested this.

Please also check my markdown - I've tried to provide a link back to the section but I can't see this rendering in the preview.